### PR TITLE
Correct builddocs setting

### DIFF
--- a/gnuradio-install.sh
+++ b/gnuradio-install.sh
@@ -5,7 +5,7 @@ sudo pip install PyBOMBS
 pybombs auto-config
 
 # Enable documentation
-pybombs config builddocs=ON
+pybombs config builddocs ON
 
 # Add default recipe lists
 pybombs recipes add-defaults


### PR DESCRIPTION
Corrected command to enable pybombs building documentation.  "builddocs=ON" is treated as a key and returns a response of "Undocumented config option".  Replacing "=" with space corrects the problem.